### PR TITLE
feat: previous week kitchen data

### DIFF
--- a/apps/web-app/app/pages/kitchen/index.vue
+++ b/apps/web-app/app/pages/kitchen/index.vue
@@ -235,7 +235,7 @@ const columns: Ref<TableColumn<KitchenWithData>[]> = ref([{
 }, {
   accessorKey: 'city',
   header: 'Населенный пункт',
-},{
+}, {
   accessorKey: 'revenueForPreviousWeek',
   header: ({ column }) => {
     const isSorted = column.getIsSorted()

--- a/apps/web-app/app/pages/kitchen/index.vue
+++ b/apps/web-app/app/pages/kitchen/index.vue
@@ -106,6 +106,9 @@
           {{ row.getValue('address') }}, {{ row.getValue('city') }}
         </div>
       </template>
+      <template #revenueForPreviousWeek-cell="{ row }">
+        <div>{{ row.getValue('revenueForPreviousWeek') }} руб</div>
+      </template>
       <template #revenueForThisWeek-cell="{ row }">
         <div>{{ row.getValue('revenueForThisWeek') }} руб</div>
       </template>
@@ -232,6 +235,21 @@ const columns: Ref<TableColumn<KitchenWithData>[]> = ref([{
 }, {
   accessorKey: 'city',
   header: 'Населенный пункт',
+},{
+  accessorKey: 'revenueForPreviousWeek',
+  header: ({ column }) => {
+    const isSorted = column.getIsSorted()
+    const icon = isSorted === 'asc' ? 'i-lucide-arrow-up-narrow-wide' : 'i-lucide-arrow-down-wide-narrow'
+
+    return h(UButton, {
+      color: 'neutral',
+      variant: 'ghost',
+      label: 'Выручка за прошлую неделю',
+      icon: isSorted ? icon : 'i-lucide-arrow-up-down',
+      class: '-mx-2.5',
+      onClick: () => column.toggleSorting(column.getIsSorted() === 'asc'),
+    })
+  },
 }, {
   accessorKey: 'revenueForThisWeek',
   header: ({ column }) => {

--- a/apps/web-app/server/tasks/kitchen/revenue-update.ts
+++ b/apps/web-app/server/tasks/kitchen/revenue-update.ts
@@ -17,16 +17,25 @@ export default defineTask({
       const thisMonday = startOfWeek(utcNow, { weekStartsOn: 1 })
       const thisSunday = endOfWeek(utcNow, { weekStartsOn: 1 })
 
-      for (const kitchen of kitchens) {
-        const revenues = await repository.kitchen.listRevenuesByKitchenForPeriod(kitchen.id, thisMonday, thisSunday)
+      // Previous week
+      const utcWeekAgo = new Date(utcNow.getTime() - 7 * 24 * 60 * 60 * 1000)
+      const prevMonday = startOfWeek(utcWeekAgo, { weekStartsOn: 1 })
+      const prevSunday = endOfWeek(utcWeekAgo, { weekStartsOn: 1 })
 
-        const revenueForThisWeek = Math.round(revenues.reduce((acc, curr) => acc + curr.total, 0))
-        if (revenueForThisWeek === kitchen.revenueForThisWeek) {
+      for (const kitchen of kitchens) {
+        const revenuesThisWeek = await repository.kitchen.listRevenuesByKitchenForPeriod(kitchen.id, thisMonday, thisSunday)
+        const revenuesPrevWeek = await repository.kitchen.listRevenuesByKitchenForPeriod(kitchen.id, prevMonday, prevSunday)
+
+        const revenueForThisWeek = Math.round(revenuesThisWeek.reduce((acc, curr) => acc + curr.total, 0))
+        const revenueForPreviousWeek = Math.round(revenuesPrevWeek.reduce((acc, curr) => acc + curr.total, 0))
+
+        if (revenueForThisWeek === kitchen.revenueForThisWeek && revenueForPreviousWeek === kitchen.revenueForPreviousWeek) {
           continue
         }
 
         await repository.kitchen.update(kitchen.id, {
           revenueForThisWeek,
+          revenueForPreviousWeek,
         })
 
         // logger.log(`Kitchen ${kitchen.id}: Revenue updated from ${kitchen.revenueForThisWeek} to ${revenueForThisWeek}`)

--- a/packages/database/src/tables.ts
+++ b/packages/database/src/tables.ts
@@ -409,6 +409,7 @@ export const kitchens = pgTable('kitchens', {
   isPickupAvailable: boolean('is_pickup_available').notNull().default(true),
   rating: numeric('rating', { mode: 'number' }).notNull().default(0),
   revenueForThisWeek: numeric('revenue_for_this_week', { mode: 'number' }).notNull().default(0),
+  revenueForPreviousWeek: numeric('revenue_for_previous_week', { mode: 'number' }).notNull().default(0),
   iikoAlias: varchar('iiko_alias').unique(),
   partnerId: cuid2('partner_id').references(() => partners.id),
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new column to the kitchen data table displaying revenue for the previous week, with sortable functionality and clear labeling.
* **Database**
  * Introduced a new field to store previous week's revenue for each kitchen.
* **Improvements**
  * Kitchen revenue data now includes both current and previous week values, ensuring more comprehensive reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->