### PR TITLE
chore: kitchens on agreement card

### DIFF
--- a/apps/web-app/app/components/AgreementFilesBlock.vue
+++ b/apps/web-app/app/components/AgreementFilesBlock.vue
@@ -24,10 +24,7 @@
 
       <template #content>
         <div class="h-auto w-56 p-4 flex flex-col gap-2">
-          <UIcon
-            :name="getFileData(file).icon"
-            class="size-10 text-muted/50"
-          />
+          <UIcon :name="getFileData(file).icon" class="size-10" />
 
           <div class="flex flex-col gap-2.5">
             <h4 class="text-base/5">

--- a/apps/web-app/app/components/PartnerAgreementCard.vue
+++ b/apps/web-app/app/components/PartnerAgreementCard.vue
@@ -63,7 +63,7 @@
         {{ agreement.comment }}
       </p>
 
-      <div v-if="agreement.kitchens.length" class="grid grid-cols-2 gap-2.5">
+      <div v-if="agreement.kitchens.length" class="grid grid-cols-1 md:grid-cols-2 gap-2.5">
         <NuxtLink
           v-for="kitchen in agreement.kitchens"
           :key="kitchen.id"

--- a/apps/web-app/app/components/PartnerAgreementCard.vue
+++ b/apps/web-app/app/components/PartnerAgreementCard.vue
@@ -63,6 +63,28 @@
         {{ agreement.comment }}
       </p>
 
+      <div v-if="agreement.kitchens.length" class="grid grid-cols-2 gap-2.5">
+        <NuxtLink
+          v-for="kitchen in agreement.kitchens"
+          :key="kitchen.id"
+          :to="`/kitchen/${kitchen.id}`"
+        >
+          <ActiveCard class="min-h-auto !p-4 !ring-accented bg-transparent">
+            <div class="shrink-0 w-full h-full flex flex-col gap-1.5 items-center justify-center text-center">
+              <UIcon name="i-lucide-store" class="size-8 text-primary" />
+
+              <h3 class="text-base/4 font-semibold">
+                {{ kitchen.address }}
+              </h3>
+
+              <h3 class="text-sm/5">
+                {{ kitchen.city }}
+              </h3>
+            </div>
+          </ActiveCard>
+        </NuxtLink>
+      </div>
+
       <div v-if="agreement.files.length" class="flex flex-col gap-1.5">
         <UButton
           v-for="file in agreement.files"
@@ -71,7 +93,7 @@
           external
           target="_blank"
           size="lg"
-          variant="subtle"
+          variant="outline"
           color="neutral"
           icon="i-lucide-file-symlink"
           :label="file.name"
@@ -82,12 +104,11 @@
 </template>
 
 <script setup lang="ts">
-import type { PartnerAgreement, PartnerAgreementFile } from '@roll-stack/database'
 import { ModalUpdatePartnerAgreement } from '#components'
 import { format } from 'date-fns'
 import { ru } from 'date-fns/locale/ru'
 
-const { agreement } = defineProps<{ agreement: PartnerAgreement & { files: PartnerAgreementFile[] } }>()
+const { agreement } = defineProps<{ agreement: PartnerAgreementWithAllData }>()
 
 const overlay = useOverlay()
 const modalUpdatePartnerAgreement = overlay.create(ModalUpdatePartnerAgreement)

--- a/apps/web-app/app/pages/agreement/index.vue
+++ b/apps/web-app/app/pages/agreement/index.vue
@@ -66,15 +66,21 @@
         {{ row.getValue('id') }}
       </template>
       <template #internalId-cell="{ row }">
-        <div class="flex flex-row gap-2 items-center">
-          <p class="text-base font-medium text-highlighted">
-            {{ row.getValue('internalId') }}
+        <div class="flex flex-col gap-0.5">
+          <div class="flex flex-row gap-2 items-center">
+            <p class="text-base font-medium text-highlighted">
+              {{ row.getValue('internalId') }}
+            </p>
+            <UIcon
+              v-if="row.getValue('isActive')"
+              name="i-lucide-check"
+              class="size-4 text-secondary"
+            />
+          </div>
+
+          <p v-if="row.original.concludedAt" class="text-xs">
+            от {{ format(new Date(row.original.concludedAt), 'd MMMM yyyy', { locale: ru }) }}
           </p>
-          <UIcon
-            v-if="row.getValue('isActive')"
-            name="i-lucide-check"
-            class="size-4 text-secondary"
-          />
         </div>
       </template>
       <template #kitchens-cell="{ row }">
@@ -98,10 +104,19 @@
         <AgreementFilesBlock :files="row.original.files" />
       </template>
       <template #royalty-cell="{ row }">
-        {{ row.getValue('royalty') }}% / от {{ formatNumber(row.getValue('minRoyaltyPerMonth')) }}
+        <div class="text-center">
+          <div>{{ row.getValue('royalty') }}%</div>
+          от {{ formatNumber(row.getValue('minRoyaltyPerMonth')) }}
+        </div>
       </template>
       <template #marketingFee-cell="{ row }">
-        {{ row.getValue('marketingFee') }}% / от {{ formatNumber(row.getValue('minMarketingFeePerMonth')) }}
+        <div v-if="row.getValue('marketingFee')" class="text-center">
+          <div>{{ row.getValue('marketingFee') }}%</div>
+          от {{ formatNumber(row.getValue('minMarketingFeePerMonth')) }}
+        </div>
+        <div v-else class="text-center">
+          -
+        </div>
       </template>
       <template #comment-cell="{ row }">
         <div class="text-sm/4 whitespace-pre-wrap max-w-56">
@@ -151,6 +166,8 @@ import type { DropdownMenuItem, TableColumn } from '@nuxt/ui'
 import type { PartnerAgreement } from '@roll-stack/database'
 import type { PartnerAgreementWithAllData } from '~/stores/partner'
 import { getPaginationRowModel } from '@tanstack/table-core'
+import { format } from 'date-fns'
+import { ru } from 'date-fns/locale/ru'
 import { upperFirst } from 'scule'
 
 const UButton = resolveComponent('UButton')
@@ -207,7 +224,7 @@ const columns: Ref<TableColumn<PartnerAgreementWithAllData>[]> = ref([{
   header: 'Кухни',
 }, {
   accessorKey: 'files',
-  header: 'Файлы / сканы',
+  header: 'Файлы',
 }, {
   accessorKey: 'legalEntity',
   header: 'Юр. лицо',

--- a/apps/web-app/app/pages/kitchen/[id].vue
+++ b/apps/web-app/app/pages/kitchen/[id].vue
@@ -6,16 +6,6 @@
         highlight
         class="flex-1 -ml-2.5"
       />
-
-      <UButton
-        size="lg"
-        variant="solid"
-        color="secondary"
-        class="w-full md:w-fit"
-        icon="i-lucide-square-pen"
-        :label="t('common.edit')"
-        @click="() => {}"
-      />
     </template>
   </Header>
 

--- a/apps/web-app/app/pages/kitchen/[id]/index.vue
+++ b/apps/web-app/app/pages/kitchen/[id]/index.vue
@@ -1,7 +1,7 @@
 <template>
   <Content>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 2xl:grid-cols-6 gap-4 md:gap-6">
-      <UCard class="col-span-1">
+      <UCard>
         <div class="shrink-0 w-full flex flex-col gap-2">
           <UIcon name="i-lucide-store" class="size-14 text-primary" />
 

--- a/apps/web-app/app/pages/kitchen/[id]/index.vue
+++ b/apps/web-app/app/pages/kitchen/[id]/index.vue
@@ -1,7 +1,7 @@
 <template>
   <Content>
-    <div class="grid grid-cols-1 gap-4 md:gap-6 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5">
-      <UCard class="col-span-2">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 2xl:grid-cols-6 gap-4 md:gap-6">
+      <UCard class="col-span-1">
         <div class="shrink-0 w-full flex flex-col gap-2">
           <UIcon name="i-lucide-store" class="size-14 text-primary" />
 

--- a/apps/web-app/app/pages/partner/[id]/agreement.vue
+++ b/apps/web-app/app/pages/partner/[id]/agreement.vue
@@ -2,7 +2,7 @@
   <Content>
     <div class="grid grid-cols-1 gap-4 md:gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       <div
-        v-for="agreement in partner?.legalEntity?.agreements"
+        v-for="agreement in agreements"
         :key="agreement.id"
         class="lg:col-span-2"
       >
@@ -28,6 +28,8 @@ const { params } = useRoute('partner-id')
 
 const partnerStore = usePartnerStore()
 const partner = computed(() => partnerStore.partners.find((partner) => partner.id === params.id))
+
+const agreements = computed(() => partnerStore.agreements.filter((agreement) => agreement.legalEntityId === partner.value?.legalEntityId))
 
 const overlay = useOverlay()
 const modalCreatePartnerAgreement = overlay.create(ModalCreatePartnerAgreement)

--- a/apps/web-app/app/pages/partner/[id]/index.vue
+++ b/apps/web-app/app/pages/partner/[id]/index.vue
@@ -1,6 +1,6 @@
 <template>
   <Content>
-    <div class="grid grid-cols-1 gap-4 md:gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-5 2xl:grid-cols-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 2xl:grid-cols-6 gap-4 md:gap-6">
       <UCard>
         <div class="shrink-0 w-full flex flex-col gap-2">
           <UIcon name="i-lucide-handshake" class="size-14 text-primary" />
@@ -67,7 +67,11 @@ const partner = computed(() => partnerStore.partners.find((partner) => partner.i
 
 const partnerUser = computed(() => partner.value?.users.find((user) => user.type === 'partner'))
 
-const activeAgreements = computed(() => partner.value?.legalEntity?.agreements.filter((agreement) => agreement.isActive))
+const activeAgreements = computed(() =>
+  partnerStore.agreements
+    .filter((agreement) => agreement.isActive === true)
+    .filter((agreement) => agreement.legalEntityId === partner.value?.legalEntityId),
+)
 
 const overlay = useOverlay()
 const modalUpdateUser = overlay.create(ModalUpdateUser)

--- a/apps/web-app/app/pages/partner/[id]/kitchens.vue
+++ b/apps/web-app/app/pages/partner/[id]/kitchens.vue
@@ -6,9 +6,7 @@
         :key="kitchen.id"
         :to="`/kitchen/${kitchen.id}`"
       >
-        <KitchenCard :kitchen="kitchen">
-          {{ kitchen }}
-        </KitchenCard>
+        <KitchenCard :kitchen="kitchen" />
       </NuxtLink>
     </div>
   </Content>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner agreement cards now show associated kitchens as clickable cards.

* **UI/Style**
  * File download button restyled for clearer visibility.
  * Responsive grid layouts updated for kitchen and partner pages (adjusted columns/breakpoints, new 2xl behavior).
  * Kitchens list and agreement table layouts reorganized (vertical kitchen links, improved agreement cells).
  * Removed an unused Edit button from the kitchen page header submenu.

* **Improvements**
  * Agreement lists are now reactive and filtered to show only relevant/active items for the selected partner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->