### PR TITLE
fix: attach logic

### DIFF
--- a/apps/web-app/app/components/UserMenu.vue
+++ b/apps/web-app/app/components/UserMenu.vue
@@ -60,7 +60,7 @@ const userMenuItems = computed(() => [
     },
   },
   {
-    label: t('app.attach.telegram.button'),
+    label: 'Telegram',
     type: 'link' as const,
     icon: 'simple-icons:telegram',
     onClick() {

--- a/apps/web-app/server/api/user/id/[userId]/telegram.post.ts
+++ b/apps/web-app/server/api/user/id/[userId]/telegram.post.ts
@@ -18,19 +18,19 @@ export default defineEventHandler(async (event) => {
       throw data
     }
 
-    const user = await repository.telegram.findUserByIdAndBotId(userId, data.botId)
-    if (!user) {
+    const user = await repository.telegram.findUserByKey(data.accessKey)
+    if (!user || user.botId !== data.botId) {
       throw createError({
         statusCode: 404,
         message: 'User not found',
       })
     }
 
-    // Guard: if accessKey is not correct
-    if (user.accessKey !== data.accessKey) {
+    // Guard: if accessKey is already used
+    if (user.userId) {
       throw createError({
         statusCode: 400,
-        message: 'Key is not correct',
+        message: 'Key is already used',
       })
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when linking a Telegram account using an access key.
  * Returns 404 “User not found” if the bot does not match or the key is invalid.
  * Returns 400 “Key is already used” if the access key has already been consumed.
  * Ensures updates proceed only for valid, unused keys, reducing mislinked accounts.

* **Refactor**
  * Streamlined user lookup to rely on access keys, simplifying the linking flow and reducing edge-case errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->