### PR TITLE
feat: startapp from telegram

### DIFF
--- a/apps/atrium-telegram/app/pages/startapp.vue
+++ b/apps/atrium-telegram/app/pages/startapp.vue
@@ -1,0 +1,27 @@
+<template>
+  <UIcon name="i-lucide-loader" class="animate-spin" />
+</template>
+
+<script setup lang="ts">
+// Data as query param from Telegram
+const separator = 'zzzzz'
+const { query } = useRoute()
+const { tgWebAppStartParam } = query
+
+if (tgWebAppStartParam?.length && tgWebAppStartParam.includes(separator)) {
+  const data = tgWebAppStartParam.toString()
+  const params = data.split(separator)
+
+  const [key, value] = params
+
+  if (!key || !value) {
+    await navigateTo('/')
+  }
+
+  if (key === 'epic') {
+    await navigateTo(`/epic/${value}`)
+  }
+} else {
+  await navigateTo('/')
+}
+</script>

--- a/apps/web-app/server/api/epic/comment/id/[commentId]/beacon.post.ts
+++ b/apps/web-app/server/api/epic/comment/id/[commentId]/beacon.post.ts
@@ -62,8 +62,26 @@ export default defineEventHandler(async (event) => {
 
       // Telegram - Atrium
       const atriumUser = user.telegramUsers.find((u) => u.botId === telegram.atriumBotId)
-      if (atriumUser) {
-        await useAtriumBot().api.sendMessage(atriumUser.telegramId, `👋 ${sender.name} ${sender.surname}\n${title}\n\n${description}`)
+      const bot = await repository.telegram.findBot(telegram.atriumBotId)
+
+      if (bot && atriumUser) {
+        const separator = 'zzzzz'
+        const startAppData = `epic${separator}${epic?.id}`
+
+        await useAtriumBot()
+          .api
+          .sendMessage(
+            atriumUser.telegramId,
+            `👋 ${sender.name} ${sender.surname}\n${title}\n\n${description}`,
+            {
+              reply_markup: {
+                inline_keyboard: [[{
+                  text: 'Открыть эпик',
+                  url: `https://t.me/${bot.username}/app?startapp=${startAppData}`,
+                }]],
+              },
+            },
+          )
       }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Telegram WebApp entry page that shows a brief loader and auto-redirects based on the start parameter, opening the target epic or returning to home if invalid.
  * Comment notifications now include an inline “Открыть эпик” button that deep-links to the epic inside the Telegram app via the bot, enabling one-tap access from Telegram messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->