### PR TITLE
feat: disabled close on swipe

### DIFF
--- a/apps/storefront-telegram/app/components/CitySelector.vue
+++ b/apps/storefront-telegram/app/components/CitySelector.vue
@@ -49,6 +49,7 @@ watch(selectedCities, () => {
   }
 
   cityStore.selected = cityStore.cities.find((c) => c.id === selectedCities.value[0])
+  selectedCities.value = []
   isCitySelectOpened.value = false
 })
 </script>

--- a/apps/storefront-telegram/app/components/UserPointsCard.vue
+++ b/apps/storefront-telegram/app/components/UserPointsCard.vue
@@ -64,6 +64,9 @@
       <UProgress
         v-model="progress"
         color="primary"
+        :ui="{
+          base: 'bg-primary/10',
+        }"
       />
     </div>
   </div>

--- a/apps/storefront-telegram/app/pages/user.vue
+++ b/apps/storefront-telegram/app/pages/user.vue
@@ -25,6 +25,19 @@
           label="Мои адреса"
           icon="i-lucide-map-pin-house"
         />
+        <UButton
+          color="neutral"
+          variant="ghost"
+          label="Мои данные"
+          icon="i-lucide-user"
+        />
+        <UButton
+          color="neutral"
+          variant="ghost"
+          :label="cityStore.selected ? cityStore.selected.name : 'Выбрать город'"
+          icon="i-lucide-locate-fixed"
+          @click="cityStore.selected = undefined"
+        />
       </UButtonGroup>
     </div>
   </PageContainer>
@@ -32,4 +45,5 @@
 
 <script setup lang="ts">
 const clientStore = useClientStore()
+const cityStore = useCityStore()
 </script>

--- a/apps/storefront-telegram/app/utils/init.ts
+++ b/apps/storefront-telegram/app/utils/init.ts
@@ -3,6 +3,7 @@ import {
   bindThemeParamsCssVars,
   bindViewportCssVars,
   closingBehavior,
+  disableVerticalSwipes,
   emitEvent,
   exitFullscreen,
   init as initSDK,
@@ -83,6 +84,11 @@ export async function init(options: {
   if (mountClosingBehavior.isAvailable()) {
     mountClosingBehavior()
     closingBehavior.enableConfirmation()
+  }
+
+  // Disable vertical swipes to prevent app close
+  if (disableVerticalSwipes.isAvailable()) {
+    disableVerticalSwipes()
   }
 
   // Orientation lock


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added “Мои данные” button and a city selection button on the user page with a dynamic label and clear action.
  * Disabled vertical swipe gestures to reduce accidental app closures in Telegram.

* Bug Fixes
  * City selection now clears after applying and closes the selector, preventing residual selections.

* Style
  * Updated user points progress bar appearance with a softer primary-tinted background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->