### PR TITLE
chore: message intro with button

### DIFF
--- a/apps/atrium-telegram/app/components/StaffBlock.vue
+++ b/apps/atrium-telegram/app/components/StaffBlock.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="max-w-full overflow-x-scroll overflow-y-hidden snap-x hide-scroll">
-    <div class="w-max flex flex-row flex-wrap gap-3.5">
+    <div class="w-max flex flex-row flex-wrap gap-1">
       <div
         v-for="user in allUsers"
         :key="user.id"
-        class="w-14 flex flex-col gap-1 justify-start items-center scroll-ml-6 snap-start motion-preset-slide-right"
+        class="w-18 flex flex-col gap-1 justify-start items-center scroll-ml-6 snap-start motion-preset-slide-right"
         @click="handleClick(user.id)"
       >
         <div class="relative">
@@ -26,7 +26,11 @@
           </div>
         </div>
 
-        <p class="text-xs/3 text-muted text-center">
+        <p class="text-xs/3 font-bold text-center line-clamp-2">
+          {{ user.name }}
+        </p>
+
+        <p class="text-xs/3 text-muted text-center line-clamp-2">
           {{ user.isOnline ? 'Онлайн' : useTimeAgoIntl(new Date(user.onlineAt ?? '')) }}
         </p>
       </div>

--- a/apps/atrium-telegram/app/pages/startapp.vue
+++ b/apps/atrium-telegram/app/pages/startapp.vue
@@ -1,5 +1,5 @@
 <template>
-  <UIcon name="i-lucide-loader" class="animate-spin" />
+  <UIcon name="i-lucide-loader" class="size-8 text-primary animate-spin" />
 </template>
 
 <script setup lang="ts">
@@ -20,6 +20,10 @@ if (tgWebAppStartParam?.length && tgWebAppStartParam.includes(separator)) {
 
   if (key === 'epic') {
     await navigateTo(`/epic/${value}`)
+  }
+
+  if (key === 'flow') {
+    await navigateTo(`/flow/${value}`)
   }
 } else {
   await navigateTo('/')

--- a/apps/web-app/server/tasks/ai/daily-report.ts
+++ b/apps/web-app/server/tasks/ai/daily-report.ts
@@ -55,13 +55,30 @@ export default defineTask({
 
       // Flow item
       const date = format(new Date(), 'd MMMM', { locale: ru })
-      await repository.flow.createItem({
+      const flowItem = await repository.flow.createItem({
         type: 'daily_task_report',
         title: `Задачи ${date}`,
         description: finalMessage,
       })
 
-      await useAtriumBot().api.sendMessage(telegram.teamGroupId, finalMessage)
+      const separator = 'zzzzz'
+      const startAppData = `flow${separator}${flowItem?.id}`
+
+      // Get first words
+      const messageIntro = finalMessage.split(' ').slice(0, 40).join(' ')
+      const preparedMessage = `${messageIntro}...\n\nПродолжение внутри Атриума? 🙃`
+
+      await useAtriumBot().api.sendMessage(telegram.teamGroupId, preparedMessage, {
+        link_preview_options: {
+          is_disabled: true,
+        },
+        reply_markup: {
+          inline_keyboard: [[{
+            text: '👉 Открыть Атриум',
+            url: `https://t.me/sushi_atrium_bot/app?startapp=${startAppData}`,
+          }]],
+        },
+      })
     } catch (error) {
       errorResolver(error)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Telegram posts now include an “Open Atrium” button that deep-links into the app using a compact start parameter.
  - Start screen supports a new “flow” start key for direct navigation; invalid params route to home.

- UI
  - Staff list: tighter spacing, wider tiles, bold multi-line names above status with consistent truncation.
  - Start screen loader: increased size and primary color.

- Content
  - Telegram messages send a short teaser instead of the full text, with the full content available inside the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->