### PR TITLE
feat: upload photo to s3

### DIFF
--- a/packages/database/src/tables.ts
+++ b/packages/database/src/tables.ts
@@ -703,6 +703,8 @@ export const ticketMessages = pgTable('ticket_messages', {
   createdAt: timestamp('created_at', { precision: 3, withTimezone: true, mode: 'string' }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { precision: 3, withTimezone: true, mode: 'string' }).notNull().defaultNow(),
   text: varchar('text').notNull(),
+  telegramFileId: varchar('telegram_file_id'),
+  fileUrl: varchar('file_url'),
   userId: cuid2('user_id').notNull().references(() => users.id, {
     onDelete: 'cascade',
     onUpdate: 'cascade',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Telegram media (photos, videos, documents) sent to the bot now appear in tickets with direct, public file links.
  - Highest-quality photo is selected automatically; captions are preserved as message text.
  - More reliable media handling with consistent file availability and improved logging for support.
- Chores
  - Expanded data model to store optional Telegram file IDs and public file URLs for each ticket message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->