### PR TITLE
feat: create flow item action

### DIFF
--- a/apps/atrium-telegram/app/components/Navigation.vue
+++ b/apps/atrium-telegram/app/components/Navigation.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="z-50 touch-pan-x sticky inset-0 h-38">
-    <div class="w-full h-14 px-4 py-0 flex flex-row flex-nowrap gap-0 items-start justify-center transition-all duration-200 ease-in-out">
+  <div class="z-50 touch-pan-x sticky inset-0 h-24">
+    <!-- <div class="w-full h-14 px-4 py-0 flex flex-row flex-nowrap gap-0 items-start justify-center transition-all duration-200 ease-in-out">
       <UButton
         v-if="isMainPage"
         variant="solid"
@@ -13,7 +13,7 @@
           leadingIcon: 'size-6 mx-auto',
         }"
       />
-    </div>
+    </div> -->
 
     <nav
       v-if="isNavigationShown"
@@ -36,5 +36,5 @@
 </template>
 
 <script setup lang="ts">
-const { isNavigationShown, mainRoutes, isMainPage } = useNavigation()
+const { isNavigationShown, mainRoutes } = useNavigation()
 </script>

--- a/apps/atrium-telegram/app/components/SectionTitle.vue
+++ b/apps/atrium-telegram/app/components/SectionTitle.vue
@@ -1,0 +1,11 @@
+<template>
+  <h2 class="text-2xl/6 font-bold tracking-tight">
+    {{ title }}
+  </h2>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title: string
+}>()
+</script>

--- a/apps/atrium-telegram/app/components/flow/ItemCard.vue
+++ b/apps/atrium-telegram/app/components/flow/ItemCard.vue
@@ -1,7 +1,16 @@
 <template>
   <ActiveCard>
     <div class="flex flex-row gap-2 items-center">
-      <UIcon name="i-lucide-clipboard-check" class="size-8 text-primary" />
+      <UAvatar
+        v-if="item.userId"
+        :src="userAvatarUrl"
+        class="size-8"
+      />
+      <UIcon
+        v-else
+        name="i-lucide-clipboard-check"
+        class="size-8 text-primary"
+      />
 
       <div v-if="!isViewed" class="flex flex-row items-center gap-1.5 text-error">
         <UIcon
@@ -49,4 +58,5 @@ const { item } = defineProps<{
 
 const userStore = useUserStore()
 const isViewed = computed(() => item.views.some((view) => view.userId === userStore?.id))
+const userAvatarUrl = computed(() => userStore.users.find((user) => user.id === item.userId)?.avatarUrl ?? undefined)
 </script>

--- a/apps/atrium-telegram/app/components/form/CreateFlowItem.vue
+++ b/apps/atrium-telegram/app/components/form/CreateFlowItem.vue
@@ -1,0 +1,90 @@
+<template>
+  <UForm
+    :validate="createValidator(createFlowItemSchema)"
+    :state="state"
+    class="flex flex-col gap-3"
+    @submit="onSubmit"
+  >
+    <UFormField
+      :label="$t('common.title')"
+      name="title"
+      required
+    >
+      <UInput
+        v-model="state.title"
+        size="xl"
+        class="w-full"
+      />
+    </UFormField>
+
+    <UFormField label="Текст" name="description">
+      <UTextarea
+        v-model="state.description"
+        placeholder="Основной текст поста"
+        autoresize
+        size="xl"
+        class="w-full"
+      />
+    </UFormField>
+
+    <UButton
+      type="submit"
+      variant="solid"
+      color="secondary"
+      size="xl"
+      block
+      class="mt-3"
+      :label="$t('common.create')"
+    />
+  </UForm>
+</template>
+
+<script setup lang="ts">
+import type { CreateFlowItem } from '#shared/services/flow'
+import type { FormSubmitEvent } from '@nuxt/ui'
+import { createFlowItemSchema } from '#shared/services/flow'
+
+const emit = defineEmits(['success', 'submitted'])
+
+const { t } = useI18n()
+const { vibrate } = useFeedback()
+const actionToast = useActionToast()
+
+const flowStore = useFlowStore()
+const userStore = useUserStore()
+
+const state = ref<Partial<CreateFlowItem>>({
+  title: undefined,
+  description: undefined,
+  type: 'user_post',
+  userId: userStore.id,
+})
+
+async function onSubmit(event: FormSubmitEvent<CreateFlowItem>) {
+  const toastId = actionToast.start()
+  emit('submitted')
+
+  try {
+    await $fetch('/api/flow', {
+      method: 'POST',
+      headers: {
+        Authorization: `tma ${userStore.initDataRaw}`,
+      },
+      body: event.data,
+    })
+
+    await Promise.all([
+      flowStore.update(),
+      userStore.update(),
+    ])
+
+    actionToast.success(toastId, t('toast.flow-item-created'))
+    vibrate('success')
+    emit('success')
+  } catch (error) {
+    console.error(error)
+    actionToast.error(toastId)
+    vibrate('error')
+  }
+}
+</script>

--- a/apps/atrium-telegram/app/composables/useNavigation.ts
+++ b/apps/atrium-telegram/app/composables/useNavigation.ts
@@ -10,7 +10,7 @@ function _useNavigation() {
   const mainRoutes = computed<NavigationRoute[]>(() => [
     {
       path: '/',
-      names: ['index', 'flow-itemId'],
+      names: ['index', 'flow-itemId', 'flow-new'],
       title: t('app.flow'),
       icon: 'i-lucide-waves',
       exact: true,

--- a/apps/atrium-telegram/app/pages/epic/[epicId]/index.vue
+++ b/apps/atrium-telegram/app/pages/epic/[epicId]/index.vue
@@ -13,9 +13,7 @@
         />
       </div>
 
-      <h1 class="text-2xl/6 font-bold">
-        {{ epic?.title }}
-      </h1>
+      <SectionTitle :title="epic?.title ?? ''" />
 
       <div class="w-full text-base/5 whitespace-pre-wrap break-words">
         {{ epic?.description }}

--- a/apps/atrium-telegram/app/pages/flow/[itemId]/index.vue
+++ b/apps/atrium-telegram/app/pages/flow/[itemId]/index.vue
@@ -2,12 +2,19 @@
   <PageContainer>
     <Section>
       <div class="flex flex-row items-start justify-between gap-2.5">
-        <UIcon name="i-lucide-clipboard-check" class="size-10 text-primary" />
+        <UAvatar
+          v-if="item?.userId"
+          :src="userAvatarUrl"
+          class="size-10"
+        />
+        <UIcon
+          v-else
+          name="i-lucide-clipboard-check"
+          class="size-10 text-primary"
+        />
       </div>
 
-      <h1 class="text-2xl/6 font-bold">
-        {{ item?.title }}
-      </h1>
+      <SectionTitle :title="item?.title ?? ''" />
 
       <div class="w-full text-base/5 whitespace-pre-wrap break-words">
         {{ item?.description }}
@@ -61,6 +68,7 @@ const { params } = useRoute('flow-itemId')
 const userStore = useUserStore()
 const flowStore = useFlowStore()
 const item = computed(() => flowStore.items.find((item) => item.id === params.itemId))
+const userAvatarUrl = computed(() => userStore.users.find((user) => user.id === item.value?.userId)?.avatarUrl ?? undefined)
 
 const isViewed = computed(() => item.value?.views.some((view) => view.userId === userStore?.id))
 

--- a/apps/atrium-telegram/app/pages/flow/new.vue
+++ b/apps/atrium-telegram/app/pages/flow/new.vue
@@ -1,0 +1,20 @@
+<template>
+  <PageContainer>
+    <div class="flex flex-col gap-2.5">
+      <SectionTitle title="Создание поста" />
+
+      <FormCreateFlowItem @success="handleSuccess()" />
+    </div>
+  </PageContainer>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  name: 'flow-new',
+  canReturn: true,
+})
+
+function handleSuccess() {
+  return navigateTo('/')
+}
+</script>

--- a/apps/atrium-telegram/app/pages/index.vue
+++ b/apps/atrium-telegram/app/pages/index.vue
@@ -1,16 +1,12 @@
 <template>
   <PageContainer :back="false" class="flex flex-col gap-y-8">
     <div class="flex flex-col gap-2.5">
-      <div class="text-2xl/6 font-bold tracking-tight">
-        Команда
-      </div>
+      <SectionTitle title="Команда" />
       <StaffBlock />
     </div>
 
     <div class="flex flex-col gap-2.5">
-      <h1 class="text-2xl/6 font-bold tracking-tight">
-        Данные на сегодня
-      </h1>
+      <SectionTitle title="Данные на сегодня" />
       <div class="grid grid-cols-2 gap-2">
         <FlowKitchensOnline />
         <FlowOrdersOnline />
@@ -20,8 +16,16 @@
     </div>
 
     <div class="flex flex-col gap-2.5">
-      <div class="text-2xl/6 font-bold tracking-tight">
-        Поток
+      <div class="flex flex-row justify-between items-center">
+        <SectionTitle title="Поток" />
+
+        <UButton
+          to="/flow/new"
+          variant="solid"
+          color="secondary"
+          icon="i-lucide-plus"
+          label="Создать пост"
+        />
       </div>
       <div class="flex flex-col gap-4">
         <NuxtLink

--- a/apps/atrium-telegram/app/pages/navigation.vue
+++ b/apps/atrium-telegram/app/pages/navigation.vue
@@ -1,7 +1,5 @@
 <template>
   <PageContainer>
-    <h1 class="text-2xl/6 font-bold tracking-tight">
-      В работе
-    </h1>
+    <SectionTitle title="В работе" />
   </PageContainer>
 </template>

--- a/apps/atrium-telegram/app/pages/no-auth.vue
+++ b/apps/atrium-telegram/app/pages/no-auth.vue
@@ -1,8 +1,6 @@
 <template>
   <PageContainer :back="false">
-    <h1 class="text-2xl">
-      Нет доступа!
-    </h1>
+    <SectionTitle title="Нет доступа!" />
     <p>Напишите в поддержку.</p>
   </PageContainer>
 </template>

--- a/apps/atrium-telegram/app/pages/tasks/index.vue
+++ b/apps/atrium-telegram/app/pages/tasks/index.vue
@@ -8,9 +8,7 @@
       />
 
       <div class="flex flex-col gap-1">
-        <h1 class="text-2xl/6 font-bold tracking-tight">
-          {{ userStore.name }}, привет!
-        </h1>
+        <SectionTitle :title="`${userStore.name}, привет!`" />
         <p class="text-base/5">
           <template v-if="taskStore.myTodayTasks.length">
             Сегодня по плану еще

--- a/apps/atrium-telegram/app/pages/ticket/[ticketId]/index.vue
+++ b/apps/atrium-telegram/app/pages/ticket/[ticketId]/index.vue
@@ -13,9 +13,7 @@
         />
       </div>
 
-      <h1 class="text-2xl/6 font-bold">
-        {{ ticket?.title }}
-      </h1>
+      <SectionTitle :title="ticket?.title ?? ''" />
 
       <div class="w-full text-base/5 whitespace-pre-wrap break-words">
         {{ ticket?.description }}

--- a/apps/atrium-telegram/app/pages/ticket/index.vue
+++ b/apps/atrium-telegram/app/pages/ticket/index.vue
@@ -1,9 +1,7 @@
 <template>
   <PageContainer>
     <div class="flex flex-col gap-2.5">
-      <div class="text-2xl/6 font-bold tracking-tight">
-        Активные тикеты
-      </div>
+      <SectionTitle title="Активные тикеты" />
       <div class="flex flex-col gap-4">
         <NuxtLink
           v-for="ticket of ticketStore.tickets"

--- a/apps/atrium-telegram/i18n/locales/ru-RU.json
+++ b/apps/atrium-telegram/i18n/locales/ru-RU.json
@@ -132,6 +132,7 @@
     "epic-created": "Эпик создан",
     "epic-updated": "Эпик обновлен",
     "epic-deleted": "Эпик удален",
-    "beacon-created": "Маяк создан"
+    "beacon-created": "Маяк создан",
+    "flow-item-created": "Пост создан"
   }
 }

--- a/apps/atrium-telegram/server/api/flow/index.post.ts
+++ b/apps/atrium-telegram/server/api/flow/index.post.ts
@@ -1,0 +1,48 @@
+import { createFlowItemSchema } from '#shared/services/flow'
+import { repository } from '@roll-stack/database'
+import { type } from 'arktype'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const body = await readBody(event)
+    const data = createFlowItemSchema(body)
+    if (data instanceof type.errors) {
+      throw data
+    }
+
+    const item = await repository.flow.createItem({
+      type: data.type,
+      title: data.title,
+      description: data.description,
+      userId: data.userId,
+    })
+    if (!item) {
+      throw createError({
+        statusCode: 500,
+        message: 'Item not created',
+      })
+    }
+
+    // Bot notification in chat
+    // if (list.chat) {
+    //   const bot = await repository.chat.findNotificationBot(list.chat.id)
+    //   if (bot) {
+    //     const text = `${event.context.user.name} ${event.context.user.surname} ${suffixByGender(['создал', 'создала'], event.context.user.gender)} задачу «${task.name}»`
+
+    //     // Send message as bot
+    //     await repository.chat.createMessage({
+    //       chatId: list.chat.id,
+    //       userId: bot.user.id,
+    //       text,
+    //     })
+    //   }
+    // }
+
+    return {
+      ok: true,
+      result: item,
+    }
+  } catch (error) {
+    throw errorResolver(error)
+  }
+})

--- a/apps/atrium-telegram/shared/services/flow.ts
+++ b/apps/atrium-telegram/shared/services/flow.ts
@@ -1,0 +1,11 @@
+import { type } from 'arktype'
+
+const flowTypeSchema = type('"user_post" | "daily_task_report" | "weekly_task_report"')
+
+export const createFlowItemSchema = type({
+  title: type('2 <= string <= 150').describe('error.length.invalid'),
+  description: type('string <= 1500 | undefined').describe('error.length.invalid').optional(),
+  type: flowTypeSchema.describe('error.length.invalid'),
+  userId: type('string | undefined').describe('error.length.invalid').optional(),
+})
+export type CreateFlowItem = typeof createFlowItemSchema.infer

--- a/apps/web-app/app/components/CheckoutCard.vue
+++ b/apps/web-app/app/components/CheckoutCard.vue
@@ -4,7 +4,7 @@
       <div class="mb-2 flex flex-row justify-between items-center">
         <div class="flex flex-row gap-3 items-center">
           <img
-            :src="`https://avatar.nextorders.ru/${checkout?.clientId}?emotion=8`"
+            :src="`https://avatar.nextorders.ru/${checkout?.id}?emotion=8`"
             width="40"
             height="40"
             alt=""

--- a/apps/web-app/app/pages/agreement/index.vue
+++ b/apps/web-app/app/pages/agreement/index.vue
@@ -38,6 +38,14 @@
           />
         </UDropdownMenu>
 
+        <UButton
+          variant="outline"
+          color="neutral"
+          size="md"
+          icon="i-lucide-copy"
+          @click="handleCopyDataClick()"
+        />
+
         <UDropdownMenu
           :items="itemsForCreateButton"
           :content="{ align: 'end' }"
@@ -339,6 +347,27 @@ const itemsForCreateButton = computed<DropdownMenuItem[]>(() => [
 ])
 
 const table = useTemplateRef('table')
+
+function convertJsonToCSV() {
+  const csvRows = partnerStore.agreements.map((row) => {
+    // Remove unnecessary data
+    const { kitchens, files, createdAt, updatedAt, legalEntity, legalEntityId, id, ...rest } = row as any
+
+    // Take only name from legalEntity
+    rest.legalEntityName = legalEntity?.name
+
+    rest.files = files.map((file: any) => file.name).join(',')
+
+    return Object.values(rest).join(';')
+  })
+
+  return csvRows.join('\n')
+}
+
+function handleCopyDataClick() {
+  const csvData = convertJsonToCSV()
+  navigator.clipboard.writeText(csvData)
+}
 
 useHead({
   title: t('app.menu.agreements'),

--- a/packages/database/src/tables.ts
+++ b/packages/database/src/tables.ts
@@ -806,6 +806,10 @@ export const flowItems = pgTable('flow_items', {
   title: varchar('title').notNull(),
   description: text('description'),
   type: varchar('type').notNull().$type<FlowItemType>(),
+  userId: cuid2('user_id').references(() => users.id, {
+    onDelete: 'cascade',
+    onUpdate: 'cascade',
+  }),
 })
 
 export const flowItemComments = pgTable('flow_item_comments', {
@@ -1312,9 +1316,13 @@ export const lockerItemDuplicateRelations = relations(lockerItemDuplicates, ({ o
   }),
 }))
 
-export const flowItemRelations = relations(flowItems, ({ many }) => ({
+export const flowItemRelations = relations(flowItems, ({ many, one }) => ({
   comments: many(flowItemComments),
   views: many(flowItemViews),
+  user: one(users, {
+    fields: [flowItems.userId],
+    references: [users.id],
+  }),
 }))
 
 export const flowItemCommentRelations = relations(flowItemComments, ({ one }) => ({

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -36,7 +36,7 @@ export type TimeZone = '+00:00'
   | '+11:00'
   | '+12:00'
 
-export type FlowItemType = 'daily_task_report' | 'weekly_task_report'
+export type FlowItemType = 'daily_task_report' | 'weekly_task_report' | 'user_post'
 
 export type Permission = InferSelectModel<typeof tables.permissions>
 export type PermissionDraft = InferInsertModel<typeof tables.permissions>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - New “Создать пост” page with a form to add flow items, accessible from the “Поток” header button; shows a success toast and returns to the main page.
  - Copy agreements data to clipboard on the Agreement page.
- Improvements
  - Unified titles across pages using a new SectionTitle component.
  - Flow items and details show user avatars when available.
  - Header and navigation layout refinements.
  - Checkout card avatar now references the correct entity.
- Localization
  - Added Russian toast message: “Пост создан”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->