### PR TITLE
fix: result from iiko

### DIFF
--- a/apps/web-app/server/api/tilda/fila.post.ts
+++ b/apps/web-app/server/api/tilda/fila.post.ts
@@ -156,7 +156,7 @@ async function sendToIntegration(data: TildaFilaBody) {
         'Authorization': `Bearer ${token}`,
       },
       body: JSON.stringify(body),
-    })
+    }).then((res) => res.json())
   } catch (error) {
     logger.error(error)
   }


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse the iiko integration response to JSON so sendToIntegration returns structured data instead of a raw Response. This fixes incorrect result handling in the Tilda Fila endpoint.

<sup>Written for commit 5f3f0cd5d79ee949f25441b1b6bf3708b09d354d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token handling in the Tilda integration: the access token is now returned and consumed as a plain string.
  * Added defensive checks and explicit error logging/500 response when token is missing.
  * Updated downstream integration calls to use the string token so deliveries requests process correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->